### PR TITLE
PWR070: Clarify requirement of explicit interfaces

### DIFF
--- a/Checks/PWR070/README.md
+++ b/Checks/PWR070/README.md
@@ -178,6 +178,14 @@ $ ./a.out
 >
 >Check the PWR070 benchmark for a demonstration!
 
+>**Note:**  
+>Beware that any procedures involving assumed-shape array arguments must have
+>explicit interfaces at the point of call. If not, the updated code won't
+>compile.
+>
+>Check the [PWR068 entry](../PWR068) for more details on implicit and explicit
+>interfaces!
+
 ### Related resources
 
 - [PWR070 source code examples](../PWR070)


### PR DESCRIPTION
Any procedures involving assumed-shape array arguments require explicit interfaces. Clarify this requirement to help update the code correctly.