### PR TITLE
Workflows: Remove `push main` action

### DIFF
--- a/.github/workflows/Test-benchmark-scripts.yml
+++ b/.github/workflows/Test-benchmark-scripts.yml
@@ -2,9 +2,6 @@
 # is simply a smoke test to check everything compiles and runs.
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Since all PRs must use the rebase-then-merge approach, the actions that are run on `main` after merging a PR serve no purpose.