### PR TITLE
Review current Fortran codes in PWRs

### DIFF
--- a/Checks/PWR005/example-omp.c
+++ b/Checks/PWR005/example-omp.c
@@ -1,9 +1,12 @@
 // PWR005: Disable default OpenMP scoping
 
 void example(int *result, unsigned size) {
-  // Default data scoping is used which may not be correct
+  int t;
+
+  // Default data scoping is used, making `t` shared instead of private
   #pragma omp parallel for
   for (int i = 0; i < size; i++) {
-    result[i] = i;
+    t = i + 1;
+    result[i] = t;
   }
 }

--- a/Checks/PWR005/example-omp.f90
+++ b/Checks/PWR005/example-omp.f90
@@ -3,11 +3,13 @@
 subroutine example(result)
   implicit none
   integer, intent(out) :: result(:)
-  integer :: i
+  integer :: i, t
 
-  ! default data scoping is used which may not be correct
+  ! Default data scoping is used, making `t` shared instead of private
   !$omp parallel do
   do i = 1, size(result, 1)
-    result(i) = i
+    t = i + 1
+    result(i) = t
   end do
+  !$omp end parallel do
 end subroutine example

--- a/Checks/PWR006/example.f90
+++ b/Checks/PWR006/example.f90
@@ -3,11 +3,13 @@
 program example
   implicit none
   integer :: i
-  integer :: sum(10)
-  integer :: a(10), b(10)
+  integer :: a(5) = [1, 2, 3, 4, 5]
+  integer :: b(5) = [6, 7, 8, 9, 10]
+  integer :: sum(5)
 
-  !$omp parallel do firstprivate(i, a, b) shared(sum)
-  do i = 1, 10
+  !$omp parallel do default(none) firstprivate(a, b) shared(sum)
+  do i = 1, 5
     sum(i) = a(i) + b(i);
   end do
+  !$omp end parallel do
 end program example

--- a/Checks/PWR009/example-omp.f90
+++ b/Checks/PWR009/example-omp.f90
@@ -1,18 +1,22 @@
 ! PWR009: Use OpenMP teams to offload work to GPU
 
-subroutine example()
+subroutine example(A, B, C)
   implicit none
-  real, dimension(100,200) :: y
-  integer(8) :: i, j
+  real, dimension(:, :), intent(in) :: A, B
+  real, dimension(:, :), intent(inout) :: C
+  integer :: i, j, k
 
-  !$omp target map(from: y(1:100, 1:200))
-  !$omp parallel default(none) private(i, j) shared(y)
-  !$omp do private(j) schedule(static)
-  do i = 1, 100
-    do j = 1, 200
-      y(i, j) = 0
+  !$omp target map(to: A, B) map(tofrom: C)
+  !$omp parallel default(none) private(i, j, k) shared(A, B, C)
+  !$omp do
+  do j = 1, size(C, 2)
+    do k = 1, size(C, 2)
+      do i = 1, size(C, 1)
+        C(i, j) = C(i, j) + A(i, k) * B(k, j)
+      end do
     end do
   end do
+  !$omp end do
   !$omp end parallel
   !$omp end target
 end subroutine example

--- a/Checks/PWR013/example-omp.f90
+++ b/Checks/PWR013/example-omp.f90
@@ -1,12 +1,15 @@
 ! PWR013: Avoid copying unused variables to the GPU
 
-subroutine example(a, b, c)
+subroutine example(A, B, C)
   implicit none
-  integer, intent(inout) :: a(100), b(100), c(100)
+  integer, intent(in) :: A(:), B(:)
+  integer, intent(inout) :: C(:)
   integer :: i
-  !$omp target teams distribute parallel do schedule(auto) shared(a, b) &
-  !$omp map(to: a(1:100), b(1:100)) map(tofrom: c(1:100))
-  do i = 1, 100
-    c(i) = c(i) + a(i)
+
+  !$omp target teams distribute parallel do schedule(auto) default(none) &
+  !$omp& shared(A, B, C) map(to: A, B) map(tofrom: C)
+  do i = 1, size(C, 1)
+    C(i) = C(i) + A(i)
   end do
+  !$omp end target teams distribute parallel do
 end subroutine example

--- a/Checks/PWR015/example-omp.f90
+++ b/Checks/PWR015/example-omp.f90
@@ -1,12 +1,15 @@
 ! PWR015: Avoid copying unnecessary array elements to the GPU
 
-subroutine example(a, c)
+subroutine example(A, B, sum)
   implicit none
-  integer, intent(inout) :: a(100), c(100)
+  integer, intent(in) :: A(:), B(:)
+  integer, intent(out) :: sum(:)
   integer :: i
-  !$omp target teams distribute parallel do schedule(auto) shared(a, b) &
-  !$omp map(to: a(0:100)) map(tofrom: c(0:100))
-  do i = 1, 50
-    c(i) = c(i) + a(i)
+
+  !$omp target parallel do default(none) shared(A, B, sum) &
+  !$omp& map(to: a, b) map(from: sum)
+  do i = 1, size(sum, 1) / 2
+    sum(i) = A(i) + B(i)
   end do
+  !$omp end target parallel do
 end subroutine example

--- a/Checks/PWR018/example.f90
+++ b/Checks/PWR018/example.f90
@@ -1,20 +1,29 @@
 ! PWR018: Call to recursive function within a loop may inhibit vectorization
 
-recursive function fibonacci(n) result(fibo)
-  implicit none
-  integer, intent(in) :: n
-  integer :: fibo
-  if (n <= 2) then
-    fibo = 1
-  else
-    fibo = fibonacci(n - 1) + fibonacci(n - 2)
-  end if
-end function fibonacci
+module mod_fibonacci
+  contains
+  recursive function fibonacci(n) result(fibo)
+    implicit none
+    integer, intent(in) :: n
+    integer :: fibo
+
+    if (n == 0) then
+      fibo = 0
+    else if (n == 1) then
+      fibo = 1
+    else
+      fibo = fibonacci(n - 1) + fibonacci(n - 2)
+    end if
+  end function fibonacci
+end module mod_fibonacci
 
 subroutine example(times)
+  use mod_fibonacci, only : fibonacci
+
   implicit none
-  integer :: sum, fibonacci
-  integer :: i, times
+  integer, intent(in) :: times
+  integer :: i, sum
+
   do i = 1, times
     sum = sum + fibonacci(i)
   end do

--- a/Checks/PWR019/example.f90
+++ b/Checks/PWR019/example.f90
@@ -4,9 +4,10 @@
 subroutine example()
   implicit none
   integer :: a(200, 10), i, j
+
   do i = 1, 200
     do j = 1, 10
-      a(j, i) = 0
+      a(i, j) = 0
     end do
   end do
 end subroutine example

--- a/Checks/PWR022/example.f90
+++ b/Checks/PWR022/example.f90
@@ -4,23 +4,23 @@ subroutine example_f(n, A, B, C, D) bind(c)
   use iso_c_binding, only : c_int, c_double
 
   implicit none
-  integer(kind=c_int) i, j, k
   integer(kind=c_int), intent(in), value :: n
-  real(kind=c_double) :: val
   real(kind=c_double), dimension(1:n), intent(in) :: A
   real(kind=c_double), dimension(1:n, 1:n), intent(in) :: B
   real(kind=c_double), dimension(1:n, 1:n, 1:n), intent(in) :: C
-  real(kind=c_double), dimension(1:n, 1:n), intent(out) :: D
+  real(kind=c_double), dimension(1:n, 1:n), intent(inout) :: D
+  integer(kind=c_int) :: i, j, k
+  real(kind=c_double) :: val
 
-  do i = 1, n
-    do k = 1, n
-      do j = 1, n
-        if (i .eq. 1) then
+  do k = 1, n
+    do j = 1, n
+      do i = 1, n
+        if (i == 1) then
           val = B(j, k)
         else
           val = D(j, k)
         end if
-        D(j, k) = val + A(i) * C(j, k, i)
+        D(j, k) = val + A(i) * C(i, j, k)
       end do
     end do
   end do

--- a/Checks/PWR022/solution.f90
+++ b/Checks/PWR022/solution.f90
@@ -4,23 +4,22 @@ subroutine solution_f(n, A, B, C, D) bind(c)
   use iso_c_binding, only : c_int, c_double
 
   implicit none
-  integer(kind=c_int) i, j, k
   integer(kind=c_int), intent(in), value :: n
-  real(kind=c_double) :: val
   real(kind=c_double), dimension(1:n), intent(in) :: A
   real(kind=c_double), dimension(1:n, 1:n), intent(in) :: B
   real(kind=c_double), dimension(1:n, 1:n, 1:n), intent(in) :: C
-  real(kind=c_double), dimension(1:n, 1:n), intent(out) :: D
+  real(kind=c_double), dimension(1:n, 1:n), intent(inout) :: D
+  integer(kind=c_int) :: i, j, k
 
   do k = 1, n
     do j = 1, n
       D(j, k) = B(j, k) + A(1) * C(j, k, 1)
     end do
   end do
-  do i = 2, n
-    do k = 1, n
-      do j = 1, n
-        D(j, k) = D(j, k) + A(i) * C(j, k, i)
+  do k = 1, n
+    do j = 1, n
+      do i = 2, n
+        D(j, k) = D(j, k) + A(i) * C(i, j, k)
       end do
     end do
   end do

--- a/Checks/PWR035/example.f90
+++ b/Checks/PWR035/example.f90
@@ -1,12 +1,13 @@
 ! PWR035: Avoid non-consecutive array access to improve performance
 
-subroutine example()
+subroutine example(a)
   implicit none
-  integer :: a(100, 100), i, j
+  integer, intent(out) :: a(:, :)
+  integer :: i, j
 
-  do i = 1, 100
-    do j = 1, 100
-      a(j, 1) = 0
+  do j = 1, size(a, 2)
+    do i = 1, size(a, 1)
+      a(1, j) = 0
     end do
   end do
 end subroutine example

--- a/Checks/PWR039/example.f90
+++ b/Checks/PWR039/example.f90
@@ -10,10 +10,10 @@ subroutine matmul_f(n, A, B, C) bind(c)
   real(kind=c_double), dimension(1:n, 1:n), intent(inout) :: C
   integer(kind=c_int) :: i, j, k
 
-  do i = 1, n
-    do j = 1, n
+  do j = 1, n
+    do i = 1, n
       do k = 1, n
-        C(j, i) = C(j, i) + A(j, k) * B(k, i)
+        C(i, j) = C(i, j) + A(i, k) * B(k, j)
       end do
     end do
   end do

--- a/Checks/PWR039/solution.f90
+++ b/Checks/PWR039/solution.f90
@@ -10,10 +10,10 @@ subroutine matmul_improved_f(n, A, B, C) bind(c)
   real(kind=c_double), dimension(1:n, 1:n), intent(inout) :: C
   integer(kind=c_int) :: i, j, k
 
-  do i = 1, n
+  do j = 1, n
     do k = 1, n
-      do j = 1, n
-        C(j, i) = C(j, i) + A(j, k) * B(k, i)
+      do i = 1, n
+        C(i, j) = C(i, j) + A(i, k) * B(k, j)
       end do
     end do
   end do

--- a/Checks/PWR040/example.f90
+++ b/Checks/PWR040/example.f90
@@ -1,14 +1,14 @@
 ! PWR040: Consider loop tiling to improve the locality of reference
 
-subroutine example(a, b, n)
+subroutine example(a, b)
   implicit none
-  integer, intent(in) :: n
-  real, dimension(1:n, 1:n), intent(inout) :: a, b
+  real, dimension(:, :), intent(out) :: a
+  real, dimension(:, :), intent(in) :: b
   integer :: i, j
 
-  do i = 1, n
-    do j = 1, n
-      a(j, i) = b(i, j)
+  do j = 1, size(a, 2)
+    do i = 1, size(a, 1)
+      a(i, j) = b(j, i)
     end do
   end do
 end subroutine example

--- a/Checks/PWR043/example.f90
+++ b/Checks/PWR043/example.f90
@@ -11,13 +11,13 @@ subroutine matmul_f(n, A, B, C) bind(c)
   integer(kind=c_int) :: i, j, k
   real(kind=c_double) :: c_aux
 
-  do i = 1, n
-    do j = 1, n
+  do j = 1, n
+    do i = 1, n
       c_aux = 0.0
       do k = 1, n
-        c_aux = c_aux + A(j, k) * B(k, i)
+        c_aux = c_aux + A(i, k) * B(k, j)
       end do
-      C(j, i) = c_aux
+      C(i, j) = c_aux
     end do
   end do
 end subroutine matmul_f

--- a/Checks/PWR043/solution.f90
+++ b/Checks/PWR043/solution.f90
@@ -10,16 +10,16 @@ subroutine matmul_improved_f(n, A, B, C) bind(c)
   real(kind=c_double), dimension(1:n, 1:n), intent(out) :: C
   integer(kind=c_int) :: i, j, k
 
-  do i = 1, n
-    do j = 1, n
-      C(j, i) = 0.0
+  do j = 1, n
+    do i = 1, n
+      C(i, j) = 0.0
     end do
   end do
 
-  do i = 1, n
+  do j = 1, n
     do k = 1, n
-      do j = 1, n
-        C(j, i) = C(j, i) + A(j, k) * B(k, i)
+      do i = 1, n
+        C(i, j) = C(i, j) + A(i, k) * B(k, j)
       end do
     end do
   end do

--- a/Checks/PWR049/example.f90
+++ b/Checks/PWR049/example.f90
@@ -1,16 +1,17 @@
 ! PWR049: Move iterator-dependent condition outside of the loop
 
-subroutine example(n)
+subroutine example(a, b)
   implicit none
-  integer, intent(in) :: n
-  integer :: i, j, a(n, n), b(n, n)
+  integer, intent(inout) :: a(:, :)
+  integer, intent(in) :: b(:, :)
+  integer :: i, j
 
-  do i = 1, n
-    do j = 1, n
-      if (j .eq. 1) then
-        a(j, i) = 0
+  do j = 1, size(a, 2)
+    do i = 1, size(a, 1)
+      if (j == 1) then
+        a(i, j) = 0
       else
-        a(j, i) = a(j - 1, i) + b(j, i)
+        a(i, j) = a(i, j - 1) + b(i, j)
       end if
     end do
   end do

--- a/Checks/PWR062/example.f90
+++ b/Checks/PWR062/example.f90
@@ -6,7 +6,7 @@ subroutine matmul_f(n, A, B, C) bind(c)
   implicit none
   integer(kind=c_int), intent(in), value :: n
   real(kind=c_double), dimension(1:n, 1:n), intent(in) :: A, B
-  real(kind=c_double), dimension(1:n, 1:n), intent(out) :: C
+  real(kind=c_double), dimension(1:n, 1:n), intent(inout) :: C
   integer(kind=c_int) :: i, j, k
 
   do j = 1, n

--- a/Checks/PWR063/README.md
+++ b/Checks/PWR063/README.md
@@ -165,7 +165,7 @@ construct and are initialized out of line using the `data` construct:
       subroutine UpdateValues(X)
         implicit none
         integer A, B, C, X
-        common /commonblock/ A, B, C
+        common /MyCommonBlock/ A, B, C
 
         A = A + X
         B = B * X
@@ -184,34 +184,34 @@ The code above may be improved if we use the `module` construct and declare and
 initialize variables simultaneously:
 
 ```f90
-      module MyModule
-        implicit none
-        integer :: A = 10, B = 20, C = 30
+module MyModule
+  implicit none
+  integer :: A = 10, B = 20, C = 30
 
-      contains
-        subroutine UpdateValues(X)
-          implicit none
-          integer :: X
+contains
+  subroutine UpdateValues(X)
+    implicit none
+    integer :: X
 
-          A = A + X
-          B = B * X
-          C = C + A + B
-        end subroutine UpdateValues
-      end module MyModule
+    A = A + X
+    B = B * X
+    C = C + A + B
+  end subroutine UpdateValues
+end module MyModule
 
-      program ModernExample
-        use MyModule
+program ModernExample
+  use MyModule, only : A, B, C, UpdateValues
 
-        implicit none
-        integer :: I
+  implicit none
+  integer :: I
 
-        do I = 1, 5
-          call UpdateValues(I)
-          write(*,*) "Update A, B, and C", A, B, C
-        end do
+  do I = 1, 5
+    call UpdateValues(I)
+    write(*,*) "Update A, B, and C", A, B, C
+  end do
 
-        write(*,*) "Final A, B, and C", A, B, C
-      end program ModernExample
+  write(*,*) "Final A, B, and C", A, B, C
+end program ModernExample
 ```
 
 This alternative program is clearer and benefits from the encapsulation provided

--- a/Checks/PWR063/README.md
+++ b/Checks/PWR063/README.md
@@ -103,7 +103,7 @@ arithmetic `if` statement:
 
 10      continue
         X(I) = I * 10
-        write(*,*) "Update X =", X
+        write(*,*) "Update X =", X(:I)
         I = I + 1
         if (I - 11) 10, 20, 30
 
@@ -125,17 +125,17 @@ We may improve the readability, intent, and maintainability of the code if we
 use a modern `do` loop construct:
 
 ```f90
-      program DoLoop
-        implicit none
-        integer I, X(10)
+program DoLoop
+  implicit none
+  integer :: I, X(10)
 
-        do I = 1, 10
-          X(I) = I * 10
-          write(*,*) "Update X =", X
-        end do
+  do I = 1, 10
+    X(I) = I * 10
+    write(*,*) "Update X =", X(:I)
+  end do
 
-        write(*, *) "Final X =", X
-      end program DoLoop
+  write(*, *) "Final X =", X
+end program DoLoop
 ```
 
 This construct provides a straightforward and safer iteration control mechanism,


### PR DESCRIPTION
This PR introduces improvements across multiple Fortran codes under PWRs. Since there are dozens of these checks, this PR focuses solely on Fortran codes with identified errors or inaccuracies (including #27).

Regarding the new indexing sequence for Fortran arrays, our previous approach involved the inverted order of `j -> i` to achieve performant memory accesses. By enforcing now the usual `i -> j -> k` sequence and interchanging the order of the `do` constructs as necessary, we retain the efficient memory accesses, while also aligning the Fortran codes with common practices and the C code examples, thus enhancing readability.