### PR TITLE
Rebrand the Open Catalog to include `correctness`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ sidebar_position: 1
 sidebar_label: Index
 ---
 
-# Open Catalog of Best Practices for Modernization and Optimization
+# Open Catalog of Code Guidelines for Correctness, Modernization, and Optimization
 
 ## About
 
 This Open Catalog is a collaborative effort to consolidate expert knowledge on
-best practices for modernizing and optimizing code written in C, C++, and
-Fortran programming languages. The Catalog consists of a comprehensive set of
-checks (rules) that describe specific issues in the source code and provide
-guidance on corrective actions, along with extensive documentation, example
-codes and references to additional reading resources.
+code guidelines for the correctness, modernization, and optimization of code
+written in C, C++, and Fortran programming languages. The Catalog consists of a
+comprehensive set of checks (rules) that describe specific issues in the source
+code and provide guidance on corrective actions, along with extensive
+documentation, example codes and references to additional reading resources.
 
 ## Benchmarks
 
@@ -20,8 +20,8 @@ The Open Catalog includes
 [a suite of microbenchmarks](https://github.com/codee-com/open-catalog/tree/main/Benchmark/)
 designed to demonstrate:
 
-- No performance degradation when implementing the modernization
-  recommendations.
+- No performance degradation when implementing the correctness and
+  modernization recommendations.
 - Potential performance enhancements achievable through the optimization
   recommendations.
 


### PR DESCRIPTION
This PR introduces a new `correctness` check category, complementing the existing `modernization` and `optimization` categories. The motivation is to prevent grouping under `modernization` checks that are not related to updating legacy code.

Take, for instance, PWR075. This check advises against relying on compiler-specific extensions. These are not generally considered legacy constructs, but they still pose a risk to code portability and consistent behavior across different environments. Consequently, PWR075 is better suited to the new `correctness` category.

The new `correctness` category is designed to encompass existing checks like PWR075 and additional ones that will be introduced in upcoming updates.