### PR TITLE
PWR007: Suggest using `implicit none (external)`

### DIFF
--- a/.github/workflows/test-benchmark-script.yml
+++ b/.github/workflows/test-benchmark-script.yml
@@ -1,7 +1,18 @@
 # IMPORTANT NOTE: The results of these benchmarks are not representative. This
 # is simply a smoke test to check everything compiles and runs.
+
 on:
   push:
+    paths:
+      - '.github/workflows/**'
+      - 'Benchmark/**'
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.f'
+      - '**/*.F'
+      - '**/*.f90'
+      - '**/*.F90'
 
 jobs:
   # Let us run this job on Ubuntu only as it is the only image that has gcc,

--- a/.github/workflows/test-benchmarks.yml
+++ b/.github/workflows/test-benchmarks.yml
@@ -3,6 +3,16 @@
 
 on:
   push:
+    paths:
+      - '.github/workflows/**'
+      - 'Benchmark/**'
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.f'
+      - '**/*.F'
+      - '**/*.f90'
+      - '**/*.F90'
 
 jobs:
   compile-and-run:

--- a/Checks/PWR007/README.md
+++ b/Checks/PWR007/README.md
@@ -20,9 +20,9 @@ legibility of the code. It can be disabled by adding an `implicit none`
 statement.
 
 > [!NOTE]
-> Implicit data typing may lead to unexpected runtime errors. For example, it may
-> change the results of the program due to implicit data typing determining the
-> type of operation used in computations. Note the example code below shows
+> Implicit data typing may lead to unexpected runtime errors. For example, it
+> may change the results of the program due to implicit data typing determining
+> the type of operation used in computations. Note the example code below shows
 > issues with integer/real division operations due to implicit data typing.
 
 > [!TIP]

--- a/Checks/PWR007/README.md
+++ b/Checks/PWR007/README.md
@@ -25,6 +25,13 @@ statement.
 > type of operation used in computations. Note the example code below shows
 > issues with integer/real division operations due to implicit data typing.
 
+> [!TIP]
+> Starting with Fortran 2018, it is possible to use the extended form
+> `implicit none (type, external)` to disable both implicit variables and
+> implicit procedures, which are called through implicit interfaces. This
+> approach mitigates the risks associated with such procedures, as outlined in
+> [PWR068](/Checks/PWR068/).
+
 ### Code example
 
 In the following example, the data type of all the variables is determined


### PR DESCRIPTION
Suggest using the extended form `implicit none (type, external)` to avoid calling procedures through implicit interfaces. I also took the chance to adjust the benchmark script actions to trigger iff we change source code. And I also formatted one line in PWR007 so it does not exceed 80 characters 😁.