### PR TITLE
Add Google Analytics, now GDPR-compliant

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -136,6 +136,10 @@ const config: Config = {
               label: 'Privacy policy',
               href: '/privacy-policy',
             },
+            {
+              label: 'Manage cookies',
+              href: '#',
+            },
           ],
         },
       ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -40,6 +40,16 @@ const config: Config = {
             'README.md',
             'Checks/**/*.md',
             'Glossary/**/*.md',
+            // Standalone pages are stored in `static/pages/**` instead of
+            // `src/pages/**` to prevent conflicts between the `mdx-loader` of
+            // the `docs` plugin and the `mdx-loader` of the `pages` plugin. If
+            // stored in `src/pages/**`, both loaders attempt to process the
+            // same Markdown file, resulting in a build failure. This issue
+            // arises because the `docs` plugin's `path` is set to the root of
+            // the repository rather than a subdirectory. We do this to align
+            // the navigation experience between the Open Catalog website and
+            // its GitHub repository.
+            'static/pages/**/*.md',
           ],
           exclude: ['**/external/**'],
           editUrl:
@@ -114,6 +124,19 @@ const config: Config = {
               href: 'https://www.codee.com/',
             },
           ]
+        },
+        {
+          title: 'Legal',
+          items: [
+            {
+              label: 'Cookie policy',
+              href: '/cookie-policy',
+            },
+            {
+              label: 'Privacy policy',
+              href: '/privacy-policy',
+            },
+          ],
         },
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Appentra Solutions, S.L.`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "jquery": "^3.7.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
+        "react-cookie-consent": "^9.0.0",
         "react-dom": "^18.0.0",
         "remark-github-admonitions-to-directives": "^2.1.0"
       },
@@ -9449,6 +9450,12 @@
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13811,6 +13818,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cookie-consent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-9.0.0.tgz",
+      "integrity": "sha512-Blyj+m+Zz7SFHYqT18p16EANgnSg2sIyU6Yp3vk83AnOnSW7qnehPkUe4+8+qxztJrNmCH5GP+VHsWzAKVOoZA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-cookie": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/react-dev-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.0.0",
         "react-cookie-consent": "^9.0.0",
         "react-dom": "^18.0.0",
+        "react-ga4": "^2.1.0",
         "remark-github-admonitions-to-directives": "^2.1.0"
       },
       "devDependencies": {
@@ -13984,6 +13985,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
       "license": "MIT"
     },
     "node_modules/react-helmet-async": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^18.0.0",
     "react-cookie-consent": "^9.0.0",
     "react-dom": "^18.0.0",
+    "react-ga4": "^2.1.0",
     "remark-github-admonitions-to-directives": "^2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jquery": "^3.7.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
+    "react-cookie-consent": "^9.0.0",
     "react-dom": "^18.0.0",
     "remark-github-admonitions-to-directives": "^2.1.0"
   },

--- a/src/components/CookieConsentBanner/CookieConsentBanner.css
+++ b/src/components/CookieConsentBanner/CookieConsentBanner.css
@@ -1,0 +1,64 @@
+:root {
+  --cookie-consent-banner-container-background-color: #000000ff;
+  --cookie-consent-banner-heading-color: #eeeeeeff;
+  --cookie-consent-banner-text-color: #94a1b2;
+  --cookie-consent-banner-button-accept-color: #0be0a6ff;
+  --cookie-consent-banner-button-accept-text-color: #000000;
+  --cookie-consent-banner-button-decline-color: #eeeeeeff;
+  --cookie-consent-banner-button-decline-text-color: #000000;
+}
+
+.cookie-consent-banner-container {
+  font-family: inherit;
+  background: var(--cookie-consent-banner-container-background-color);
+  color: var(--cookie-consent-banner-text-color);
+  padding: 25px;
+  width: calc(100% - 60px);
+  max-width: 400px;
+  border-radius: 8px;
+  box-shadow: 0px 8px 12px rgba(0, 0, 0, 0.45);
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+}
+
+.cookie-consent-banner-buttons {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+@media (max-width: 768px) {
+  .cookie-consent-banner-buttons {
+    flex-direction: column;
+  }
+}
+
+.cookie-consent-banner-button {
+  font-family: inherit;
+  font-weight: bold;
+  text-align: center;
+  user-select: text;
+  padding: 10px 0px;
+  border: none;
+  border-radius: 4px;
+  flex: 1;
+}
+
+.cookie-consent-banner-button:hover {
+  cursor: pointer;
+}
+
+.cookie-consent-banner-button-accept {
+  background: var(--cookie-consent-banner-button-accept-color);
+  color: var(--cookie-consent-banner-button-accept-text-color);
+}
+
+.cookie-consent-banner-button-decline {
+  background: var(--cookie-consent-banner-button-decline-color);
+  color: var(--cookie-consent-banner-button-decline-text-color);
+}

--- a/src/components/CookieConsentBanner/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner/CookieConsentBanner.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react';
+import CookieConsent, { getCookieConsentValue, OPTIONS, VISIBLE_OPTIONS } from 'react-cookie-consent';
+import ReactGA from 'react-ga4';
+import Link from '@docusaurus/Link';
+
+import './CookieConsentBanner.css';
+
+const CookieConsentBannerImpl = () => {
+  const cookieName: string = 'CookieConsent';
+  const googleAnalyticsTrackingId: string = 'G-178ZNT1Z63';
+  // Store the banner state in memory to maintain consistency across route
+  // changes. For example, if the banner is visible, ensure it remains visible
+  // when navigating between pages.
+  const isMinimizedValueInMemoryKey: string = 'CookieConsentIsMinimized';
+
+  const getIsMinimizedValueFromMemory = (): undefined | boolean => {
+    const isMinimizedValueInMemory: null | string =
+      window.sessionStorage.getItem(isMinimizedValueInMemoryKey);
+    if (isMinimizedValueInMemory === null) {
+      return undefined;
+    }
+    return JSON.parse(isMinimizedValueInMemory) === true;
+  };
+  const setIsMinimizedValueInMemory = (value: boolean): void => {
+    window.sessionStorage.setItem(isMinimizedValueInMemoryKey, JSON.stringify(value));
+  };
+  const initializeGoogleAnalytics = (): void => {
+    ReactGA.initialize([{ trackingId: googleAnalyticsTrackingId }]);
+  };
+  const resetGoogleAnalytics = (): void => {
+    ReactGA.reset();
+  };
+  const getCookieValue = (): undefined | boolean => {
+    const cookieValue: undefined | string = getCookieConsentValue(cookieName);
+    if (cookieValue === undefined) {
+      return undefined;
+    }
+    return cookieValue === 'true';
+  };
+
+  const [isMinimized, setIsMinimized] = useState(() => {
+    const isMinimizedValueInMemory: undefined | boolean = getIsMinimizedValueFromMemory();
+    if (isMinimizedValueInMemory === undefined) {
+      // If `isMinimizedValueInMemory` is undefined, we decide whether to show
+      // the banner by checking if the value of the cookie is also undefined. If
+      // the cookie is undefined, it means it is the first time the user visits
+      // the website; therefore, prompt the banner
+      return getCookieValue() !== undefined;
+    }
+    return isMinimizedValueInMemory;
+  });
+
+  const handleAccept = () => {
+    initializeGoogleAnalytics();
+    setIsMinimized(true);
+  };
+  const handleDecline = () => {
+    resetGoogleAnalytics();
+    setIsMinimized(true);
+  };
+  const handleExpand = () => {
+    setIsMinimized(false);
+  };
+
+  useEffect(() => {
+    setIsMinimizedValueInMemory(isMinimized);
+  }, [isMinimized]);
+  useEffect(() => {
+    if (getCookieValue() === true) {
+      initializeGoogleAnalytics();
+    }
+  }, []);
+
+  return (
+    <>
+      {!isMinimized && (
+        <CookieConsent
+          cookieName={cookieName}
+
+          buttonText='Accept'
+          declineButtonText='Decline'
+
+          onAccept={handleAccept}
+          onDecline={handleDecline}
+          enableDeclineButton={true}
+          acceptOnScroll={false}
+
+          location={OPTIONS.NONE}
+          visible={VISIBLE_OPTIONS.SHOW}
+
+          disableStyles={true}
+
+          containerClasses='cookie-consent-banner-container'
+          buttonWrapperClasses='cookie-consent-banner-buttons'
+          buttonClasses='cookie-consent-banner-button cookie-consent-banner-button-accept'
+          declineButtonClasses='cookie-consent-banner-button cookie-consent-banner-button-decline'
+        >
+          <h3 style={{ color: 'var(--cookie-consent-banner-heading-color)' }}>
+            🍪 We use cookies!
+          </h3>
+          <p>
+            We only use cookies to enhance your experience and improve our site. Is
+            that okay with you?
+          </p>
+          <p>
+            <Link
+              to='/cookie-policy'
+              style={{
+                color: 'var(--cookie-consent-banner-heading-color)',
+                textDecoration: 'underline',
+              }}
+            >
+              Read more
+            </Link>
+          </p>
+        </CookieConsent>
+      )}
+      <Link to='#' className='footer__link-item' onClick={(e) => {
+        // Prevent the default anchor behavior to avoid scrolling the page to
+        // the top when the link is clicked.
+        e.preventDefault();
+        handleExpand();
+      }}>Manage cookies</Link>
+    </>
+  );
+};
+
+// Wrapper over the actual `CookieConsentBanner` to make sure it only renders
+// in the client. This helps avoiding errors with Server-Side Rendering (SSR)!
+const CookieConsentBanner = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+  return isMounted ? <CookieConsentBannerImpl /> : null;
+}
+
+export default CookieConsentBanner;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -174,3 +174,8 @@ table.dataTable tbody tr:nth-child(even) {
 table.dataTable tbody tr:hover {
   background-color: var(--ifm-color-highlight-light);
 }
+
+/* Class to hide a directoy or document from the sidebar */
+.sidebar_hidden {
+  display: none !important;
+}

--- a/src/theme/Footer/LinkItem/index.tsx
+++ b/src/theme/Footer/LinkItem/index.tsx
@@ -6,6 +6,7 @@ import isInternalUrl from '@docusaurus/isInternalUrl';
 import IconExternalLink from '@theme/Icon/ExternalLink';
 import type {Props} from '@theme/Footer/LinkItem';
 import { Icon } from '@iconify/react';
+import CookieConsentBanner from '@site/src/components/CookieConsentBanner/CookieConsentBanner';
 
 export default function FooterLinkItem({item}: Props): JSX.Element {
   const {to, href, label, prependBaseUrlToHref, ...props} = item;
@@ -13,6 +14,11 @@ export default function FooterLinkItem({item}: Props): JSX.Element {
   const normalizedHref = useBaseUrl(href, {forcePrependBaseUrl: true});
   const icon = props['icon'] as string;
 
+  if (label == 'Manage cookies') {
+    // Render the CookieConsentBanner directly instead of a regular footer link
+    // to allow interactive cookie management without navigating away.
+    return <CookieConsentBanner />;
+  }
   return (
     <Link
       className="footer__link-item"

--- a/static/_category_.json
+++ b/static/_category_.json
@@ -1,0 +1,4 @@
+{
+  "className": "sidebar_hidden",
+  "position": 9999
+}

--- a/static/pages/legal/cookie-policy.md
+++ b/static/pages/legal/cookie-policy.md
@@ -1,0 +1,82 @@
+---
+slug: /cookie-policy
+pagination_next: null
+pagination_prev: null
+custom_edit_url: null
+---
+
+# Cookie policy
+
+In compliance with the provisions of Law 34/2002, of July 11, on Services of the
+Information Society and Electronic Commerce (LSSI) and in compliance with the
+European Directive 2009/136 / CE, we inform the user that Appentra Solutions SL
+(hereinafter, "Appentra") as the owner of the website
+https://open-catalog.codee.com/, which uses cookies on it (hereinafter,
+"Website").
+
+This Cookie policy applies to the Website and is part of the
+[Privacy policy](/privacy-policy), applying the same meaning to the terms
+defined there.
+
+## What are cookies?
+
+Cookies are small data files that are downloaded to the user's device when
+accessing the Website. Cookies allow you to store and retrieve information about
+the browsing habits of a user or their equipment and, depending on the
+information they contain and the way they use their equipment, they can be used
+to recognize the user.
+
+## What types of cookies does the Website use?
+
+The cookies used on the Website belong to the following categories:
+
+- Technical cookies: Cookies necessary for navigation and proper functioning of
+the Website. Its use allows access to pages of the Website, to carry out
+verification processes, security, traffic control and data communication. The
+legal basis is the provision of these services and they are necessary for the
+provision of the same.
+- Analytical cookies: Which allow keeping statistics for the optimization and
+improvement of the user's experience on the Website. They allow the visitor to
+be identified anonymously to keep an approximate count of the number of visitors
+and their trend over time, to know which content is the most visited, to know if
+the user is new or repeats visit.
+
+In the following table we show the particular cookies used on the Website:
+
+| Cookie           | Type       | Duration  | Description                                                                                                                                                                                                                                                                                                         |
+| ---------------- | ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CookieConsent`  | Technical  | 1 year    | This cookie is set by our cookie consent banner and is used to store whether the user consented to the use of cookies. It does not store any personal data                                                                                                                                                          |
+| `_ga`            | Analytical | 2 years   | This cookie is set by Google Analytics. The cookie is used to calculate visitor, session and campaign data and to keep track of site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to identify unique visitors                           |
+| `_ga_178ZNT1Z63` | Analytical | 2 years   | This cookie is set by Google Analytics. The cookie stores session data and is used to track user interactions and engagement across the site. The data collected helps generate anonymized analytics reports                                                                                                        |
+
+## Blocking or elimination of cookies
+
+Notwithstanding the foregoing and the technical cookies strictly necessary for
+the provision of our services, the user has the possibility of configuring their
+browser to be notified of the receipt of cookies and prevent their installation
+on their equipment. However, disabling cookies may affect the proper functioning
+of certain sections of the Website.
+
+Likewise, the user has the possibility to revoke at any time the consent given
+for the use of cookies by Appentra, without affecting the illegality of the
+treatment based on the consent prior to its withdrawal, configuring their
+browser in the terms provided in the previous point.
+
+Consult the instructions and manuals of your browser for more information:
+
+- [Microsoft Edge](https://support.microsoft.com/en-us/windows/manage-cookies-in-microsoft-edge-view-allow-block-delete-and-use-168dab11-0753-043d-7c16-ede5947fc64d#ie=ie-10)
+- [Google Chrome](https://support.google.com/chrome/answer/95647)
+- [Firefox](https://support.mozilla.org/en-US/kb/clear-cookies-and-site-data-firefox?redirectslug=delete-cookies-remove-info-websites-stored&redirectlocale=en-US)
+- [Safari](https://support.apple.com/en-lb/guide/safari/sfri11471/16.0/mac/11.0)
+
+You can also deactivate specific third-party cookies through the following page
+managed by the EDAA (European Interactive Digital Advertising Alliance):
+https://www.youronlinechoices.com/.
+
+Additionally, you can manage your cookie preferences at any time by clicking the
+"Manage cookies" link at the bottom of the page.
+
+## Contact us
+
+If you have any questions about our use of cookies, please feel free to contact
+us at info@codee.com.

--- a/static/pages/legal/privacy-policy.md
+++ b/static/pages/legal/privacy-policy.md
@@ -1,0 +1,46 @@
+---
+slug: /privacy-policy
+pagination_next: null
+pagination_prev: null
+custom_edit_url: null
+---
+
+# Privacy policy
+
+This policy establishes our privacy practices and explains how we handle the
+information we collect when you visit and use our sites, services, products and
+content ("Services").
+
+This policy does not apply to information collected by third party websites
+linked to or otherwise accessible by Codee. Information collected or received by
+third party services is subject to their own privacy policies.
+
+Unless a specific local regulation establishes otherwise, this Privacy policy is
+governed by the laws of Spain.
+
+## Responsible for data processing
+
+Appentra Solutions SL (hereinafter "Codee" or "us"), as the Data Controller,
+domiciled at P.º Marítimo, 22b, 15679 Cambre, A Coruña, undertakes to comply
+with the provisions of Organic Law 3/2018, of December 5, on the Protection of
+Personal Data and guarantee of digital rights (LOPDGDD) and with REGULATION
+(EU) 2016 / 679 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of April 27, 2016
+regarding the protection of natural persons with regard to the processing of
+personal data and the free circulation of these data (RGPD).
+
+All communications related to the processing of your personal data should be
+addressed to our Data Protection Officer at info@codee.com.
+
+## What information do we collect and store?
+
+We do not collect any type of personal data.
+
+## Changes to this policy
+
+We reserve the right to modify the terms of this Privacy policy and will notify
+you by clear notice of these changes on our website and in this Privacy policy.
+
+## Contact us
+
+If you have any questions about our privacy policy, please feel free to contact
+us at info@codee.com.


### PR DESCRIPTION
This pull request introduces Google Analytics integration to the Open Catalog. To ensure compliance with privacy standards, a Cookie Consent Banner is displayed first, requesting the user's permission before tracking any data.

![Screenshot From 2025-01-31 09-33-29](https://github.com/user-attachments/assets/b52dd35a-36f8-4a0e-b5f7-dd68017a5a2d)
![Screenshot From 2025-01-31 09-33-50](https://github.com/user-attachments/assets/9e66ce58-fff8-4ac8-b4a0-37ab6790b3bb)
![Screenshot From 2025-01-31 09-34-30](https://github.com/user-attachments/assets/ce750186-a2ae-4827-b1b4-787cde4b5b37)
