### PR TITLE
Add PWR037: Potential precision loss in call to mathematical function

### DIFF
--- a/Benchmark/cmake/modules/Benchmark.cmake
+++ b/Benchmark/cmake/modules/Benchmark.cmake
@@ -41,6 +41,7 @@ function(add_benchmark CHECKID)
   target_link_libraries(${CHECKID}
     PUBLIC
       benchmark::benchmark
+      m
   )
 
   target_include_directories(${CHECKID}

--- a/Benchmark/src/CMakeLists.txt
+++ b/Benchmark/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_benchmark(PWR003)
 add_benchmark(PWR022)
 add_benchmark(PWR032)
+add_benchmark(PWR037)
 add_benchmark(PWR039)
 add_benchmark(PWR043)
 add_benchmark(PWR062)

--- a/Benchmark/src/PWR037.cpp
+++ b/Benchmark/src/PWR037.cpp
@@ -1,0 +1,54 @@
+#include "Benchmark.h"
+
+// Forward-declare the functions to benchmark
+extern "C" {
+void compute_damped_sinusoid(const int n, const double *timesteps,
+                             const double amplitude,
+                             const double angularFrequency,
+                             const double decayRate, const double phaseShift,
+                             double *results);
+void compute_damped_sinusoid_improved(const int n, const double *timesteps,
+                                      const double amplitude,
+                                      const double angularFrequency,
+                                      const double decayRate,
+                                      const double phaseShift, double *results);
+}
+
+// Size adjusted to fit execution on micro-seconds
+constexpr int N = 1024 * 1024;
+constexpr double AMPLITUDE = 1.0;
+constexpr double ANGULAR_FREQUENCY = 2.0;
+constexpr double DECAY_RATE = 0.5;
+constexpr double PHASE_SHIFT = 3.141592653589793 / 4;
+
+#if OCB_ENABLE_C
+
+static void CExampleBench(benchmark::State &state) {
+  const auto timesteps = OpenCatalog::CreateRandomVector<double>(N, 0.0, 10.0);
+  auto results = OpenCatalog::CreateUninitializedVector<double>(N);
+
+  for (auto _ : state) {
+    compute_damped_sinusoid(N, timesteps.data(), AMPLITUDE, ANGULAR_FREQUENCY,
+                            DECAY_RATE, PHASE_SHIFT, results.data());
+    benchmark::DoNotOptimize(results);
+  }
+}
+
+static void CImprovedBench(benchmark::State &state) {
+  const auto timesteps = OpenCatalog::CreateRandomVector<double>(N, 0.0, 10.0);
+  auto results = OpenCatalog::CreateUninitializedVector<double>(N);
+
+  for (auto _ : state) {
+    compute_damped_sinusoid_improved(N, timesteps.data(), AMPLITUDE,
+                                     ANGULAR_FREQUENCY, DECAY_RATE, PHASE_SHIFT,
+                                     results.data());
+    benchmark::DoNotOptimize(results);
+  }
+}
+
+// A performance impact is expected when performing higher-precision
+// calculations
+OC_BENCHMARK("PWR037 C Example", CExampleBench);
+OC_BENCHMARK("PWR037 C Fixed", CImprovedBench);
+
+#endif

--- a/Checks/PWR037/README.md
+++ b/Checks/PWR037/README.md
@@ -1,3 +1,115 @@
 # PWR037: Potential precision loss in call to mathematical function
 
-We are working on this recommendation and it will be available soon.
+### Issue
+
+Calling a mathematical function intended for a smaller data type results in
+lower-precision operations and potential loss of information.
+
+### Actions
+
+Replace the mathematical function call with the appropriate alternative version
+that matches the input data type.
+
+### Relevance
+
+The C programming language does not support function overloading, which would
+allow multiple functions to share the same name but handle different argument
+types. To address this limitation, the standard library of C provides multiple
+versions of mathematical functions, each tailored to specific data types. For
+example:
+
+- `sqrtf()` for `float`.
+- `sqrt()` for `double`.
+- `sqrtl()` for `long double`.
+
+Using a function intended for a smaller data type, such as `sqrtf()` with a
+`double` input, causes an implicit narrowing of the input value. This implicit
+type conversion is allowed by the compiler, but results in a loss of precision
+that can propagate through chained calculations, impacting the overall accuracy
+of the program.
+
+### Code example
+
+Consider the following code, which demonstrates the loss of precision when
+using `sqrtf()` with a `double` input:
+
+```c
+// example.c
+#include <math.h>
+#include <stdio.h>
+
+__attribute__((const)) double square_root(const double value) {
+  return sqrtf(value);
+}
+
+int main() {
+  printf("Square root of 2 is: %0.15f\n", square_root(2.0));
+}
+```
+
+Compiling and running this code produces an approximation of the square root of
+2:
+
+```txt
+$ gcc --version    
+gcc (Debian 12.2.0-14) 12.2.0
+$ gcc example.c -lm -o example
+$ ./example
+Square root of 2 is: 1.41421 35381 69861
+```
+
+Note the error in the result beyond the seventh decimal place. The accurate
+approximation for the square root of 2 would be `1.41421 35623 73095`. The
+mismatch corresponds to the 7-digit precision limit of the `float` data type on
+systems using IEEE-754 floating-point arithmetic, like `x86`.
+
+Although the error might seem small, such inaccuracies can rapidly compound
+across chained computations, resulting in significant deviations from the
+expected results.
+
+To fix this issue, simply replace the `sqrtf()` call with `sqrt()` to leverage
+the `double` precision:
+
+```c
+// solution.c
+...
+
+__attribute__((const)) double square_root(const double value) {
+  return sqrt(value);
+}
+
+...
+```
+
+Compiling and running the corrected code procedures a more accurate
+approximation of the square root of 2:
+
+```txt
+$ gcc solution.c -lm -o solution
+$ ./solution
+Square root of 2 is: 1.41421 35623 73095
+```
+
+> [!IMPORTANT]
+> While higher-precision calculations may come with a slight performance cost,
+> they help ensure the accuracy and reliability of the code. Instead, if the
+> intended choice is to use the lower-precision calculation, adjust the data
+> type of the variable to ensure it matches the called function.
+
+### Related resources
+
+- [PWR037
+  examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR037/)
+
+### References
+
+- ["Common mathematical
+functions"](https://en.cppreference.com/w/c/numeric/math), cppreference.com.
+[last checked December 2024]
+
+- ["Function overloading"](https://en.wikipedia.org/wiki/Function_overloading),
+Wikipedia Contributors. [last checked December 2024]
+
+- ["IEEE
+754"](https://en.wikipedia.org/wiki/IEEE_754#Basic_and_interchange_formats),
+Wikipedia Contributors. [last checked December 2024]

--- a/Checks/PWR037/benchmark/example.c
+++ b/Checks/PWR037/benchmark/example.c
@@ -1,0 +1,17 @@
+// PWR037: Potential precision loss in call to mathematical function
+
+#include <math.h>
+
+// https://en.wikipedia.org/wiki/Damping#Damped_sine_wave
+void compute_damped_sinusoid(const int n, const double *timesteps,
+                             const double amplitude,
+                             const double angularFrequency,
+                             const double decayRate, const double phaseShift,
+                             double *results) {
+
+  for (int i = 0; i < n; ++i) {
+    double exponentialDecay = expf(-decayRate * timesteps[i]);
+    double angle = angularFrequency * timesteps[i] + phaseShift;
+    results[i] = amplitude * exponentialDecay * cosf(angle);
+  }
+}

--- a/Checks/PWR037/benchmark/solution.c
+++ b/Checks/PWR037/benchmark/solution.c
@@ -1,0 +1,18 @@
+// PWR037: Potential precision loss in call to mathematical function
+
+#include <math.h>
+
+// https://en.wikipedia.org/wiki/Damping#Damped_sine_wave
+void compute_damped_sinusoid_improved(const int n, const double *timesteps,
+                                      const double amplitude,
+                                      const double angularFrequency,
+                                      const double decayRate,
+                                      const double phaseShift,
+                                      double *results) {
+
+  for (int i = 0; i < n; ++i) {
+    double exponentialDecay = exp(-decayRate * timesteps[i]);
+    double angle = angularFrequency * timesteps[i] + phaseShift;
+    results[i] = amplitude * exponentialDecay * cos(angle);
+  }
+}

--- a/Checks/PWR037/solution.c
+++ b/Checks/PWR037/solution.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 __attribute__((const)) double square_root(const double value) {
-  return sqrtf(value);
+  return sqrt(value);
 }
 
 int main() {


### PR DESCRIPTION
Add entry and benchmark for a check that was already defined. My results:

```txt
$ lscpu
  Model name:             13th Gen Intel(R) Core(TM) i7-13700H

$ gcc --version
gcc (Debian 12.2.0-14) 12.2.0

$ ./run-benchmarks.py --check PWR037
-----------------------------------------------------------
Benchmark                 Time             CPU   Iterations
-----------------------------------------------------------
PWR037 C Example      15610 us        15607 us           45
PWR037 C Fixed        22523 us        22517 us           31
```

Note that the performance impact is expected when performing higher-precision calculations. Still, the check helps ensure the accuracy and reliability of the code.