### PR TITLE
Highlight `pure` incompatibility with OpenMP and OpenACC directives for parallelization

### DIFF
--- a/Checks/PWR003/README.md
+++ b/Checks/PWR003/README.md
@@ -136,6 +136,11 @@ end module example_module
   * However, the function also modifies `c`, memory outside of its scope, thus
     leading to a "normal" function.
 
+>[!WARNING]
+> Fortran procedures marked with the `pure` attribute do not allow
+> OpenACC/OpenMP parallelization directives. Be aware of this limitation in
+> case you intend to use them.
+
 ### Related resources
 
 * [PWR003 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR003/)

--- a/Checks/PWR050/README.md
+++ b/Checks/PWR050/README.md
@@ -103,6 +103,11 @@ subroutine example(D, X, Y, a)
 end subroutine example
 ```
 
+>[!WARNING]
+> OpenMP parallelization directives are not allowed in Fortran procedures
+> marked with the `pure` attribute. To enable their use, `pure` must be
+> removed.
+
 ### Related resources
 
 * [PWR050 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR050/)

--- a/Checks/PWR051/README.md
+++ b/Checks/PWR051/README.md
@@ -127,6 +127,11 @@ end function example
 > balancing synchronization and memory overheads, by taking advantage of a
 > reduction mechanism typically supported by the APIs for multithreading.
 
+>[!WARNING]
+> OpenMP parallelization directives are not allowed in Fortran procedures
+> marked with the `pure` attribute. To enable their use, `pure` must be
+> removed.
+
 ### Related resources
 
 * [PWR051 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR051/)

--- a/Checks/PWR052/README.md
+++ b/Checks/PWR052/README.md
@@ -122,6 +122,11 @@ end subroutine example
 > efficient implementation that balances synchronization and memory overheads
 > must be explored for each particular code.
 
+>[!WARNING]
+> OpenMP parallelization directives are not allowed in Fortran procedures
+> marked with the `pure` attribute. To enable their use, `pure` must be
+> removed.
+
 ### Related resources
 
 * [PWR052 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR052/)

--- a/Checks/PWR055/README.md
+++ b/Checks/PWR055/README.md
@@ -109,6 +109,11 @@ subroutine example(D, X, Y, a)
 end subroutine example
 ```
 
+>[!WARNING]
+> OpenACC/OpenMP offloading directives are not allowed in Fortran procedures
+> marked with the `pure` attribute. To enable their use, `pure` must be
+> removed.
+
 ### Related resources
 
 * [PWR055 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR055/)

--- a/Checks/PWR056/README.md
+++ b/Checks/PWR056/README.md
@@ -123,6 +123,11 @@ function example(A) result(sum)
 end function example
 ```
 
+>[!WARNING]
+> OpenACC/OpenMP offloading directives are not allowed in Fortran procedures
+> marked with the `pure` attribute. To enable their use, `pure` must be
+> removed.
+
 ### Related resources
 
 * [PWR056 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR056/)

--- a/Checks/PWR057/README.md
+++ b/Checks/PWR057/README.md
@@ -115,6 +115,11 @@ subroutine example(A, nodes)
 end subroutine example
 ```
 
+>[!WARNING]
+> OpenACC/OpenMP offloading directives are not allowed in Fortran procedures
+> marked with the `pure` attribute. To enable their use, `pure` must be
+> removed.
+
 ### Related resources
 
 * [PWR057 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR057/)


### PR DESCRIPTION
Clarifications are added as new alerts to the descriptions of relevant checks.