### PR TITLE
Replace `parameter` with `argument` when referring to a procedure's arguments

### DIFF
--- a/Checks/PWR001/README.md
+++ b/Checks/PWR001/README.md
@@ -1,15 +1,15 @@
-# PWR001: Declare global variables as function parameters
+# PWR001: Pass global variables as function arguments
 
 ### Issue
 
 Best programming practices recommend writing self-contained functions, meaning
 that all the global variables used in the function must be declared locally
-either as parameters or as local variables in the function body.
+either as arguments or as local variables in the function body.
 
 ### Actions
 
 Explicitly declare all the global variables read or written in the function
-either as parameters or as local variables in the function body, including the
+either as arguments or as local variables in the function body, including the
 output variables.
 
 ### Relevance
@@ -30,7 +30,7 @@ optimization.
 > leading to deep code refactorizations. In some situations, an alternative
 > approach would be to outline the critical loop into a separate function. In
 > case there is a single output variable, the function return value may be used
-> instead of a parameter.
+> instead of an argument.
 
 > [!NOTE]
 > Enforcing this recommendation may be critical in the case the functions to be
@@ -43,7 +43,7 @@ optimization.
 
 In the following example, the flow of the data across function calls is not
 explicit. The global variables `A` and `B` are read or written in functions
-`init` and `add`. As the functions have no parameters, it is necessary to keep
+`init` and `add`. As the functions have no arguments, it is necessary to keep
 track of the read and write operations to `A` and `B` across multiple functions
 (and in real codes even across multiple files).
 
@@ -71,7 +71,7 @@ void example() {
 }
 ```
 
-When the arrays are passed explicitly as function parameters, with a simple
+When the arrays are passed explicitly as function arguments, with a simple
 glance at the code you notice which are the arrays involved during the execution
 of function `example`. In the refactored code the inputs and outputs of the
 function calls `init(A)` and `add(A, B)` are explicit, so it is easier to

--- a/Checks/PWR001/example.c
+++ b/Checks/PWR001/example.c
@@ -1,4 +1,4 @@
-// PWR001: Declare global variables as function parameters
+// PWR001: Pass global variables as function arguments
 
 #define N 100
 

--- a/Checks/PWR001/example.f90
+++ b/Checks/PWR001/example.f90
@@ -1,4 +1,4 @@
-! PWR001: Declare global variables as function parameters
+! PWR001: Pass global variables as function arguments
 
 module globalsMod
   use iso_fortran_env, only: real32

--- a/Checks/PWR008/README.md
+++ b/Checks/PWR008/README.md
@@ -1,17 +1,17 @@
-# PWR008: Declare the intent for each procedure parameter
+# PWR008: Declare the intent for each procedure argument
 
 ### Issue
 
-Each procedure parameter should have its intent declared to facilitate reasoning
+Each procedure argument should have its intent declared to facilitate reasoning
 about the flow of data in and out of the function.
 
 ### Actions
 
-Declare the proper intent for each procedure parameter.
+Declare the proper intent for each procedure argument.
 
 ### Relevance
 
-By declaring the intent of each procedure parameter the flow of data in and out
+By declaring the intent of each procedure argument the flow of data in and out
 of the function is made explicit in the source code. This not only improves code
 legibility but also allows reasoning about what the procedure does: by including
 all data inputted and outputted by a procedure in its signature, the
@@ -28,7 +28,7 @@ programming best practices.
 
 ### Code example
 
-In the following example, the intent of all the parameters of the function is
+In the following example, the intent of all the arguments of the function is
 not explicit in the code:
 
 ```fortran
@@ -47,7 +47,7 @@ contains
 end program example
 ```
 
-By enforcing the explicit declaration of the intent of the parameters of the
+By enforcing the explicit declaration of the intent of the arguments of the
 function, the source code looks as follows:
 
 ```fortran

--- a/Checks/PWR008/example.f90
+++ b/Checks/PWR008/example.f90
@@ -1,4 +1,4 @@
-! PWR008: Declare the intent for each procedure parameter
+! PWR008: Declare the intent for each procedure argument
 
 subroutine example(a, b)
   implicit none

--- a/Checks/PWR012/README.md
+++ b/Checks/PWR012/README.md
@@ -1,13 +1,13 @@
-# PWR012: Pass only required fields from derived data types as parameters
+# PWR012: Pass only required fields from derived data types as arguments
 
 ### Issue
 
-Pass only used fields from derived data types as parameters to promote data
+Pass only used fields from derived data types as arguments to promote data
 hiding.
 
 ### Actions
 
-Pass the used fields as separate parameters instead of the whole derived type.
+Pass the used fields as separate arguments instead of the whole derived type.
 
 ### Relevance
 
@@ -16,9 +16,9 @@ move around related variables. While in many cases this is an effective method
 to organize data, the compilers can have a hard time optimizing this code
 because increased visibility of data also renders optimizations more complex.
 
-Functions having derived data types used as parameters should make use of most
+Functions having derived data types used as arguments should make use of most
 if not all its fields. Ensuring that all fields from derived types passed as
-function parameters are used in the function body has several benefits: promotes
+function arguments are used in the function body has several benefits: promotes
 data hiding, makes inputs and outputs more explicit, helps to prevent unintended
 variable modifications, and also contributes to improve compiler and static
 analyzer code coverage.
@@ -179,11 +179,11 @@ end program example
 
 * [PWR012 examples](https://github.com/codee-com/open-catalog/tree/main/Checks/PWR012/)
 
-* [PWR001: Declare global variables as function parameters](../PWR001/README.md)
+* [PWR001: Declare global variables as function arguments](../PWR001/README.md)
 
 * [PWR002: Declare scalar variables in the smallest possible scope](../PWR002/README.md)
 
-* [PWR008: Declare the intent for each procedure parameter](../PWR008/README.md)
+* [PWR008: Declare the intent for each procedure argument](../PWR008/README.md)
 
 * [PWD006: Missing deep copy of non-contiguous data to the GPU](../PWD006/README.md)
 

--- a/Checks/PWR012/example.c
+++ b/Checks/PWR012/example.c
@@ -1,4 +1,4 @@
-// PWR012: Pass only required fields from derived type as parameters
+// PWR012: Pass only required fields from derived type as arguments
 
 #include <stdlib.h>
 

--- a/Checks/PWR012/example.f90
+++ b/Checks/PWR012/example.f90
@@ -1,4 +1,4 @@
-! PWR012: Pass only required fields from derived type as parameters
+! PWR012: Pass only required fields from derived type as arguments
 
 program example
 

--- a/Checks/PWR023/README.md
+++ b/Checks/PWR023/README.md
@@ -1,15 +1,15 @@
-# PWR023: Add `restrict` for pointer function parameters to hint the compiler that vectorization is safe
+# PWR023: Add `restrict` for pointer function arguments to hint the compiler that vectorization is safe
 
 ### Issue
 
-Use `restrict` for pointer function parameters to hint the compiler that there
+Use `restrict` for pointer function arguments to hint the compiler that there
 is no [pointer aliasing](../../Glossary/Pointer-aliasing.md) preventing
 [vectorization](../../Glossary/Vectorization.md).
 
 ### Actions
 
 Verify that there is no aliasing at the call sites and add `restrict` to the
-pointer function parameters.
+pointer function arguments.
 
 ### Relevance
 

--- a/Checks/PWR023/README.md
+++ b/Checks/PWR023/README.md
@@ -1,4 +1,4 @@
-# PWR023: Add `restrict` for pointer function arguments to hint the compiler that vectorization is safe
+# PWR023: Add 'restrict' for pointer function arguments to hint the compiler that vectorization is safe
 
 ### Issue
 

--- a/Checks/PWR023/example.c
+++ b/Checks/PWR023/example.c
@@ -1,4 +1,4 @@
-// PWR023: add ‘restrict’ for pointer function arguments to hint the compiler
+// PWR023: Add 'restrict' for pointer function arguments to hint the compiler
 // that vectorization is safe
 
 int example(int *x, int *y) {

--- a/Checks/PWR023/example.c
+++ b/Checks/PWR023/example.c
@@ -1,4 +1,4 @@
-// PWR023: add ‘restrict’ for pointer function parameters to hint the compiler
+// PWR023: add ‘restrict’ for pointer function arguments to hint the compiler
 // that vectorization is safe
 
 int example(int *x, int *y) {

--- a/Checks/PWR025/README.md
+++ b/Checks/PWR025/README.md
@@ -13,7 +13,7 @@ Annotate the pure function with `#pragma omp declare simd`.
 A loop invoking functions tends to make it difficult for the compiler to
 [vectorize](../../Glossary/Vectorization.md). However, calls to some functions can be
 vectorized. Calls to a pure function (function whose return value depends only
-on function parameters) can be vectorized if the compiler is instructed to do so
+on function arguments) can be vectorized if the compiler is instructed to do so
 with a compiler pragma.
 
 > [!NOTE]

--- a/Checks/PWR071/README.md
+++ b/Checks/PWR071/README.md
@@ -56,8 +56,8 @@ end program test_discouraged_real_types
 ```
 
 To conveniently control the program's precision and ensure portability, it is
-recommended to use a central module where different `kind` parameters are
-defined, either using `selected_real_kind()`, or the `iso_fortran_env` module.
+recommended to use a central module where different `kind` values are defined,
+either using `selected_real_kind()`, or the `iso_fortran_env` module.
 
 Let's start with an example using `selected_real_kind()`, which allows to
 specify a minimum amount of significant digits and exponent range:

--- a/Glossary/Variable-scope.md
+++ b/Glossary/Variable-scope.md
@@ -10,7 +10,7 @@ In C/C++ there are the following scopes:
 accessible from the place of definition until the end of the block where it is
 defined. In C++, blocks are delimited with curly brackets `{}`.
 
-* Function scope - function parameters have a function scope and can be used
+* Function scope - function arguments have a function scope and can be used
 anywhere inside the function.
 
 * File scope - defined outside functions, these variables are visible from the

--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ designed to demonstrate:
 
 | ID                       | Title                                                                                          | Category                                           | C | Fortran | C++ | AutoFix |
 |:------------------------:|:----------------------------------------------------------------------------------------------:|:--------------------------------------------------:|:-:|:-------:|:---:|:-------:|
-| [PWR001](Checks/PWR001/) | Declare global variables as function parameters                                                | correctness, modernization, security               | ✓ | ✓       | ✓   |         |
+| [PWR001](Checks/PWR001/) | Pass global variables as function arguments                                                    | correctness, modernization, security               | ✓ | ✓       | ✓   |         |
 | [PWR002](Checks/PWR002/) | Declare scalar variables in the smallest possible scope                                        | correctness, security                              | ✓ |         | ✓   |         |
 | [PWR003](Checks/PWR003/) | Explicitly declare pure functions                                                              | modernization, security, optimization              | ✓ | ✓       | ✓   |         |
 | [PWR004](Checks/PWR004/) | Declare OpenMP scoping for all variables                                                       | correctness                                        | ✓ | ✓       | ✓   |         |
 | [PWR005](Checks/PWR005/) | Disable default OpenMP scoping                                                                 | correctness                                        | ✓ | ✓       | ✓   |         |
 | [PWR006](Checks/PWR006/) | Avoid privatization of read-only variables                                                     | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR007](Checks/PWR007/) | Disable implicit declaration of variables                                                      | correctness, modernization, security               |   | ✓       |     | ✓[^1]   |
-| [PWR008](Checks/PWR008/) | Declare the intent for each procedure parameter                                                | correctness, modernization, security               |   | ✓       |     | ✓[^1]   |
+| [PWR008](Checks/PWR008/) | Declare the intent for each procedure argument                                                 | correctness, modernization, security               |   | ✓       |     | ✓[^1]   |
 | [PWR009](Checks/PWR009/) | Use OpenMP teams to offload work to GPU                                                        | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR010](Checks/PWR010/) | Avoid column-major array access in C/C++                                                       | optimization                                       | ✓ |         | ✓   |         |
-| [PWR012](Checks/PWR012/) | Pass only required fields from derived type as parameters                                      | modernization, optimization                        | ✓ | ✓       | ✓   |         |
+| [PWR012](Checks/PWR012/) | Pass only required fields from derived type as arguments                                       | modernization, optimization                        | ✓ | ✓       | ✓   |         |
 | [PWR013](Checks/PWR013/) | Avoid copying unused variables to or from the GPU                                              | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR014](Checks/PWR014/) | Out-of-dimension-bounds matrix access                                                          | correctness, security                              | ✓ |         | ✓   |         |
 | [PWR015](Checks/PWR015/) | Avoid copying unnecessary array elements to or from the GPU                                    | optimization                                       | ✓ | ✓       | ✓   |         |
@@ -51,7 +51,7 @@ designed to demonstrate:
 | [PWR020](Checks/PWR020/) | Consider loop fission to enable vectorization                                                  | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR021](Checks/PWR021/) | Consider loop fission with scalar to vector promotion to enable vectorization                  | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR022](Checks/PWR022/) | Move invariant conditional out of the loop to facilitate vectorization                         | optimization                                       | ✓ | ✓       | ✓   |         |
-| [PWR023](Checks/PWR023/) | Add 'restrict' for pointer function parameters to hint the compiler that vectorization is safe | optimization                                       | ✓ |         | ✓   |         |
+| [PWR023](Checks/PWR023/) | Add 'restrict' for pointer function arguments to hint the compiler that vectorization is safe  | optimization                                       | ✓ |         | ✓   |         |
 | [PWR024](Checks/PWR024/) | Loop can be rewritten in OpenMP canonical form                                                 | optimization                                       | ✓ |         | ✓   |         |
 | [PWR025](Checks/PWR025/) | Consider annotating pure function with OpenMP 'declare simd'                                   | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR026](Checks/PWR026/) | Annotate function for OpenMP Offload                                                           | optimization                                       | ✓ | ✓       | ✓   |         |


### PR DESCRIPTION
Various naming aspects of the Open Catalog aren't applicable to Fortran. For example, multiple recommendations used `parameter` to refer to a procedure's arguments; this is valid for C/C++, but confusing for Fortran since `parameter` is a reserved keyword. Let's consistently use `argument`, which is valid for all languages.

There are other pending issues, like the fact that C/C++ only have `functions`, while Fortran has both `functions` and `subroutines`, which can be referred to as `procedures`. However, this is not a usual term for C/C++. We'll evaluate how to address these more conflicting issues later on, as there's no simple solution for all languages.