### PR TITLE
PWR007: Expand on the `external` property

### DIFF
--- a/Checks/PWR007/example_procedure.f90
+++ b/Checks/PWR007/example_procedure.f90
@@ -1,0 +1,11 @@
+! PWR007: Disable the implicit declaration of variables and procedures
+
+program example
+  use iso_fortran_env, only: real32
+  implicit none
+  real(kind=real32) :: number, result
+
+  number = 5
+  call factorial(number, result)
+  print *, "Factorial of", number, "is", result
+end program example

--- a/Checks/PWR007/example_procedure_factorial.f90
+++ b/Checks/PWR007/example_procedure_factorial.f90
@@ -1,0 +1,14 @@
+! PWR007: Disable the implicit declaration of variables and procedures
+
+! NOT-PWR068: The subroutine doesn't provide an explicit interface on purpose
+pure subroutine factorial(number, result)
+  implicit none
+  integer, intent(in) :: number
+  integer, intent(out) :: result
+  integer :: i
+
+  result = 1
+  do i = 1, number
+    result = result * i
+  end do
+end subroutine factorial

--- a/Checks/PWR007/example_procedure_with_implicit.f90
+++ b/Checks/PWR007/example_procedure_with_implicit.f90
@@ -1,0 +1,11 @@
+! PWR007: Disable the implicit declaration of variables and procedures
+
+program example
+  use iso_fortran_env, only: real32
+  implicit none(type, external)
+  real(kind=real32) :: number, result
+
+  number = 5
+  call factorial(number, result)
+  print *, "Factorial of", number, "is", result
+end program example

--- a/Checks/PWR007/example_variable.f90
+++ b/Checks/PWR007/example_variable.f90
@@ -1,4 +1,4 @@
-! PWR007: Disable implicit declaration of variables
+! PWR007: Disable the implicit declaration of variables and procedures
 
 program example
   ! NOT-PWR071: We`re using implicit typing on purpose

--- a/Checks/PWR007/solution_procedure.f90
+++ b/Checks/PWR007/solution_procedure.f90
@@ -1,0 +1,11 @@
+! PWR007: Disable the implicit declaration of variables and procedures
+
+program solution
+  use mod_factorial, only: factorial
+  implicit none(type, external)
+  integer :: number, result
+
+  number = 5
+  call factorial(number, result)
+  print *, "Factorial of", number, "is", result
+end program solution

--- a/Checks/PWR007/solution_procedure_factorial.f90
+++ b/Checks/PWR007/solution_procedure_factorial.f90
@@ -1,0 +1,17 @@
+! PWR007: Disable the implicit declaration of variables and procedures
+
+module mod_factorial
+  implicit none
+contains
+  pure subroutine factorial(number, result)
+    implicit none
+    integer, intent(in) :: number
+    integer, intent(out) :: result
+    integer :: i
+
+    result = 1
+    do i = 1, number
+      result = result * i
+    end do
+  end subroutine factorial
+end module mod_factorial

--- a/Checks/PWR007/solution_variable.f90
+++ b/Checks/PWR007/solution_variable.f90
@@ -1,4 +1,4 @@
-! PWR007: Disable implicit declaration of variables
+! PWR007: Disable the implicit declaration of variables and procedures
 
 program solution
   use iso_fortran_env, only: real32

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ designed to demonstrate:
 | [PWR004](Checks/PWR004/) | Declare OpenMP scoping for all variables                                                       | correctness                                        | ✓ | ✓       | ✓   |         |
 | [PWR005](Checks/PWR005/) | Disable default OpenMP scoping                                                                 | correctness                                        | ✓ | ✓       | ✓   |         |
 | [PWR006](Checks/PWR006/) | Avoid privatization of read-only variables                                                     | optimization                                       | ✓ | ✓       | ✓   |         |
-| [PWR007](Checks/PWR007/) | Disable implicit declaration of variables                                                      | correctness, modernization, security               |   | ✓       |     | ✓[^1]   |
+| [PWR007](Checks/PWR007/) | Disable the implicit declaration of variables and procedures                                   | correctness, modernization, security               |   | ✓       |     | ✓[^1]   |
 | [PWR008](Checks/PWR008/) | Declare the intent for each procedure argument                                                 | correctness, modernization, security               |   | ✓       |     | ✓[^1]   |
 | [PWR009](Checks/PWR009/) | Use OpenMP teams to offload work to GPU                                                        | optimization                                       | ✓ | ✓       | ✓   |         |
 | [PWR010](Checks/PWR010/) | Avoid column-major array access in C/C++                                                       | optimization                                       | ✓ |         | ✓   |         |


### PR DESCRIPTION
773f71a included the `implicit none(type, external)` tip, but the rest of the entry wasn't updated. This commit renames and expands PWR007 to highlight how it helps with implicit procedure symbols in addition to implicit variables.