### PR TITLE
Allow to filter the checks table through the URL hash

### DIFF
--- a/src/scripts/custom.js
+++ b/src/scripts/custom.js
@@ -83,6 +83,22 @@ const createDataTable = async () => {
                 dataTable.column(2).search(searchValue).draw();
                 jQuery(node).addClass('dt-button-clicked');
                 jQuery(node).siblings().removeClass('dt-button-clicked');
+                if (searchValue) {
+                  // Set the category as the URL hash; this way, users can easily
+                  // share the view to the table
+                  //
+                  // Note: The preferred approach would be to use Docusaurus'
+                  // routing capabilities, instead of the default browser API.
+                  // However, they would require to wrap all this code into a
+                  // React component that is imported in the plain `.md` file. We
+                  // had something like this in the past for another
+                  // functionality, and decided to refactor the underlying
+                  // problem to not pollute the plain `.md` file view, which is
+                  // rendered as-is in GitHub.
+                  window.history.replaceState(null, '', `#${searchValue}`);
+                } else { // All checks, just remove the URL hash
+                  window.history.replaceState(null, '', window.location.pathname);
+                }
               }
             })),
           ]

--- a/src/scripts/custom.js
+++ b/src/scripts/custom.js
@@ -102,16 +102,30 @@ const createDataTable = async () => {
   }
 };
 
+const syncDataTableWithURL = async (location) => {
+  const { default: jQuery } = await import('jquery');
+
+  const hash = location.hash.toLowerCase().substr(1); // (0) is the `#` part
+  // Allow an empty `hash` to go through, since it matches the "All checks"
+  // option
+  const categoryButton = jQuery(`#filter-button-${hash}`);
+  if (categoryButton.length == 1) {
+    categoryButton.first().trigger('click');
+  }
+}
+
 // Add here actions that must be run after Docusaurus has made the DOM
 // available for further manipulation
-export function onRouteDidUpdate({ location, previousLocation }) {
-  // Abort if we are still on the same page; the action fires even when
-  // navigating within the same page (e.g., between `#` headings)
-  if (location.pathname !== previousLocation?.pathname) {
-
-    // Main `README.md`
-    if (location.pathname === '/') {
-      createDataTable();
+export async function onRouteDidUpdate({ location, previousLocation }) {
+  // Main `README.md`
+  if (location.pathname === '/') {
+    // Omit if we are still on the same page; the action fires even when
+    // navigating within the same page (e.g., between `#` headings)
+    if (location.pathname !== previousLocation?.pathname) {
+      // Wait until the table is loaded since there are dependant actions
+      await createDataTable();
     }
+
+    syncDataTableWithURL(location);
   }
 }

--- a/src/scripts/custom.js
+++ b/src/scripts/custom.js
@@ -76,6 +76,9 @@ const createDataTable = async () => {
               { 'label': 'Optimization', 'searchValue': 'optimization' },
             ].map(({ label, searchValue }) => ({
               'text': label,
+              'attr': {
+                id: `filter-button-${searchValue}`
+              },
               'action': (event, dataTable, node, config) => {
                 dataTable.column(2).search(searchValue).draw();
                 jQuery(node).addClass('dt-button-clicked');


### PR DESCRIPTION
This PR allows to append the name of the categories (`correctness`, `modernization`, `security`, `portability`, `optimization`) to the main page URL as a hash (e.g., `open-catalog.codee.com/#correctness`) to automatically filter the starting view.